### PR TITLE
chore(keys): Add more validation to scoped-key input params.

### DIFF
--- a/dist/fxa-crypto-relier/fxa-crypto-deriver.amd.js
+++ b/dist/fxa-crypto-relier/fxa-crypto-deriver.amd.js
@@ -82113,6 +82113,9 @@ var jose = __webpack_require__(73);
 
 var KEY_LENGTH = 48;
 var LEGACY_SYNC_SCOPE = 'https://identity.mozilla.com/apps/oldsync';
+var REGEX_HEX32 = /^[0-9a-f]{32}$/i;
+var REGEX_HEX64 = /^[0-9a-f]{64}$/i;
+var REGEX_TIMESTAMP = /^[0-9]{13}$/;
 
 /**
  * Scoped key deriver
@@ -82160,28 +82163,28 @@ var ScopedKeys = function () {
       var _this = this;
 
       return new Promise(function (resolve) {
-        if (!options.inputKey) {
-          throw new Error('inputKey required');
+        if (!REGEX_HEX64.test(options.inputKey)) {
+          throw new Error('inputKey must be a 64-character hex string');
         }
 
-        if (!options.keyRotationSecret) {
-          throw new Error('keyRotationSecret required');
+        if (!REGEX_HEX64.test(options.keyRotationSecret)) {
+          throw new Error('keyRotationSecret must be a 64-character hex string');
         }
 
-        if (!options.keyRotationTimestamp) {
-          throw new Error('keyRotationTimestamp required');
+        if (typeof options.keyRotationTimestamp !== 'number') {
+          throw new Error('keyRotationTimestamp must be a 13-digit integer');
         }
 
-        if (!options.identifier) {
-          throw new Error('identifier required');
+        if (!REGEX_TIMESTAMP.test(options.keyRotationTimestamp)) {
+          throw new Error('keyRotationTimestamp must be a 13-digit integer');
         }
 
-        if (!options.uid) {
-          throw new Error('uid required');
+        if (typeof options.identifier !== 'string' || options.identifier.length < 10) {
+          throw new Error('identifier must be a string of length >= 10');
         }
 
-        if (options.keyRotationTimestamp.toString().length !== 13) {
-          throw new Error('keyRotationTimestamp must be a 13-digit number');
+        if (!REGEX_HEX32.test(options.uid)) {
+          throw new Error('uid must be a 32-character hex string');
         }
 
         if (options.identifier === LEGACY_SYNC_SCOPE) {

--- a/dist/fxa-crypto-relier/fxa-crypto-deriver.js
+++ b/dist/fxa-crypto-relier/fxa-crypto-deriver.js
@@ -82123,6 +82123,9 @@ var jose = __webpack_require__(73);
 
 var KEY_LENGTH = 48;
 var LEGACY_SYNC_SCOPE = 'https://identity.mozilla.com/apps/oldsync';
+var REGEX_HEX32 = /^[0-9a-f]{32}$/i;
+var REGEX_HEX64 = /^[0-9a-f]{64}$/i;
+var REGEX_TIMESTAMP = /^[0-9]{13}$/;
 
 /**
  * Scoped key deriver
@@ -82170,28 +82173,28 @@ var ScopedKeys = function () {
       var _this = this;
 
       return new Promise(function (resolve) {
-        if (!options.inputKey) {
-          throw new Error('inputKey required');
+        if (!REGEX_HEX64.test(options.inputKey)) {
+          throw new Error('inputKey must be a 64-character hex string');
         }
 
-        if (!options.keyRotationSecret) {
-          throw new Error('keyRotationSecret required');
+        if (!REGEX_HEX64.test(options.keyRotationSecret)) {
+          throw new Error('keyRotationSecret must be a 64-character hex string');
         }
 
-        if (!options.keyRotationTimestamp) {
-          throw new Error('keyRotationTimestamp required');
+        if (typeof options.keyRotationTimestamp !== 'number') {
+          throw new Error('keyRotationTimestamp must be a 13-digit integer');
         }
 
-        if (!options.identifier) {
-          throw new Error('identifier required');
+        if (!REGEX_TIMESTAMP.test(options.keyRotationTimestamp)) {
+          throw new Error('keyRotationTimestamp must be a 13-digit integer');
         }
 
-        if (!options.uid) {
-          throw new Error('uid required');
+        if (typeof options.identifier !== 'string' || options.identifier.length < 10) {
+          throw new Error('identifier must be a string of length >= 10');
         }
 
-        if (options.keyRotationTimestamp.toString().length !== 13) {
-          throw new Error('keyRotationTimestamp must be a 13-digit number');
+        if (!REGEX_HEX32.test(options.uid)) {
+          throw new Error('uid must be a 32-character hex string');
         }
 
         if (options.identifier === LEGACY_SYNC_SCOPE) {

--- a/src/deriver/ScopedKeys.js
+++ b/src/deriver/ScopedKeys.js
@@ -8,6 +8,9 @@ const jose = require('node-jose');
 
 const KEY_LENGTH = 48;
 const LEGACY_SYNC_SCOPE = 'https://identity.mozilla.com/apps/oldsync';
+const REGEX_HEX32 = /^[0-9a-f]{32}$/i;
+const REGEX_HEX64 = /^[0-9a-f]{64}$/i;
+const REGEX_TIMESTAMP = /^[0-9]{13}$/;
 
 /**
  * Scoped key deriver
@@ -45,28 +48,28 @@ class ScopedKeys {
    */
   deriveScopedKey(options) {
     return new Promise((resolve) => {
-      if (! options.inputKey) {
-        throw new Error('inputKey required');
+      if (! REGEX_HEX64.test(options.inputKey)) {
+        throw new Error('inputKey must be a 64-character hex string');
       }
 
-      if (! options.keyRotationSecret) {
-        throw new Error('keyRotationSecret required');
+      if (! REGEX_HEX64.test(options.keyRotationSecret)) {
+        throw new Error('keyRotationSecret must be a 64-character hex string');
       }
 
-      if (! options.keyRotationTimestamp) {
-        throw new Error('keyRotationTimestamp required');
+      if (typeof options.keyRotationTimestamp !== 'number') {
+        throw new Error('keyRotationTimestamp must be a 13-digit integer');
       }
 
-      if (! options.identifier) {
-        throw new Error('identifier required');
+      if (! REGEX_TIMESTAMP.test(options.keyRotationTimestamp)) {
+        throw new Error('keyRotationTimestamp must be a 13-digit integer');
       }
 
-      if (! options.uid) {
-        throw new Error('uid required');
+      if (typeof options.identifier !== 'string' || options.identifier.length < 10) {
+        throw new Error('identifier must be a string of length >= 10');
       }
 
-      if (options.keyRotationTimestamp.toString().length !== 13) {
-        throw new Error('keyRotationTimestamp must be a 13-digit number');
+      if (! REGEX_HEX32.test(options.uid)) {
+        throw new Error('uid must be a 32-character hex string');
       }
 
       if (options.identifier === LEGACY_SYNC_SCOPE) {

--- a/test/deriver/ScopedKeys.js
+++ b/test/deriver/ScopedKeys.js
@@ -70,26 +70,190 @@ describe('ScopedKeys', function () {
       });
   });
 
-  it('validates keyRotationTimestamp', () => {
+  it('validates that inputKey is provided', () => {
+    return scopedKeys.deriveScopedKey({
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'inputKey must be a 64-character hex string');
+    });
+  });
+
+  it('validates that inputKey is a hex string', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: 'k' + sampleKb.slice(1),
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'inputKey must be a 64-character hex string');
+    });
+  });
+
+  it('validates that inputKey has the required length', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb.slice(0, 16),
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'inputKey must be a 64-character hex string');
+    });
+  });
+
+  it('validates that keyRotationSecret is provided', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'keyRotationSecret must be a 64-character hex string');
+    });
+  });
+
+  it('validates that keyRotationSecret is a hex string', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: 'Q' + keyRotationSecret.slice(1),
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'keyRotationSecret must be a 64-character hex string');
+    });
+  });
+
+  it('validates that keyRotationSecret has the required length', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret.slice(0, 16),
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'keyRotationSecret must be a 64-character hex string');
+    });
+  });
+
+  it('validates that keyRotationTimestamp is provided', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret,
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'keyRotationTimestamp must be a 13-digit integer');
+    });
+  });
+
+  it('validates that keyRotationTimestamp is a number', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: '1111111111111',
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'keyRotationTimestamp must be a 13-digit integer');
+    });
+  });
+
+  it('validates that keyRotationTimestamp is an integer', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: 1234567890.23,
+      identifier: identifier,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'keyRotationTimestamp must be a 13-digit integer');
+    });
+  });
+
+  it('validates that keyRotationTimestamp has correct number of digits', () => {
     return scopedKeys.deriveScopedKey({
       inputKey: sampleKb,
       keyRotationSecret: keyRotationSecret,
       keyRotationTimestamp: 100,
       identifier: identifier,
       uid: uid
-    }).catch((err) => {
-      assert.equal(err.message, 'keyRotationTimestamp must be a 13-digit number');
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'keyRotationTimestamp must be a 13-digit integer');
     });
   });
 
-  it('validates uid', () => {
+  it('validates that identifier is provided', () => {
     return scopedKeys.deriveScopedKey({
       inputKey: sampleKb,
       keyRotationSecret: keyRotationSecret,
-      keyRotationTimestamp: 100,
+      keyRotationTimestamp: keyRotationTimestamp,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'identifier must be a string of length >= 10');
+    });
+  });
+
+  it('validates that identifier is a string', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: true,
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'identifier must be a string of length >= 10');
+    });
+  });
+
+  it('validates that identifier is of non-trivial length', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: 'https://x',
+      uid: uid
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'identifier must be a string of length >= 10');
+    });
+  });
+
+  it('validates that uid is provided', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: keyRotationTimestamp,
       identifier: identifier
-    }).catch((err) => {
-      assert.equal(err.message, 'uid required');
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'uid must be a 32-character hex string');
+    });
+  });
+
+  it('validates that uid is a hex string', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: identifier,
+      uid: '!' + uid.slice(1)
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'uid must be a 32-character hex string');
+    });
+  });
+
+  it('validates that uid has the correct length', () => {
+    return scopedKeys.deriveScopedKey({
+      inputKey: sampleKb,
+      keyRotationSecret: keyRotationSecret,
+      keyRotationTimestamp: keyRotationTimestamp,
+      identifier: identifier,
+      uid: uid.slice(0, 16)
+    }).then(assert.fail, (err) => {
+      assert.equal(err.message, 'uid must be a 32-character hex string');
     });
   });
 


### PR DESCRIPTION
When addressing @shane-tomlinson's feedback from the #14, I noticed that `Buffer.from(string, 'hex')` will silently truncate its input at the first non-hex character:

```
> Buffer.from('abcdxf1234', 'hex')
<Buffer ab cd>
```

In the interests of extreme paranoia, I'm going to add a bunch of extra validation to those inputs to ensure that things go exactly as we expect.  This first push is just to see the tests fail, actual validation code incoming...